### PR TITLE
add for PixartDenoiseAction and PixArtWrapper

### DIFF
--- a/hcpdiff/models/wrapper/pixart.py
+++ b/hcpdiff/models/wrapper/pixart.py
@@ -2,6 +2,16 @@ from .sd import SD15Wrapper
 from hcpdiff.utils import pad_attn_bias
 
 class PixArtWrapper(SD15Wrapper):
+    def forward_TE(self, prompt_ids, timesteps, attn_mask=None, plugin_input={}, **kwargs):
+        # T5Encoder do not need position_ids (It use relative position embedding for key and query)
+        input_all = dict(prompt_ids=prompt_ids, timesteps=timesteps, attn_mask=attn_mask, **plugin_input)
+        if hasattr(self.TE, 'input_feeder'):
+            for feeder in self.TE.input_feeder:
+                feeder(input_all)
+        # Get the text embedding for conditioning
+        encoder_hidden_states = self.TE(prompt_ids, attention_mask=attn_mask, output_hidden_states=True)[0]
+        return encoder_hidden_states
+        
     def forward_denoiser(self, x_t, prompt_ids, encoder_hidden_states, timesteps, attn_mask=None, position_ids=None, resolution=None, aspect_ratio=None,
                      plugin_input={}, **kwargs):
         if attn_mask is not None:

--- a/hcpdiff/models/wrapper/pixart.py
+++ b/hcpdiff/models/wrapper/pixart.py
@@ -26,4 +26,6 @@ class PixArtWrapper(SD15Wrapper):
         added_cond_kwargs = {"resolution":resolution, "aspect_ratio":aspect_ratio}
         model_pred = self.denoiser(x_t, encoder_hidden_states, timesteps, encoder_attention_mask=attn_mask,
                                added_cond_kwargs=added_cond_kwargs).sample  # Predict the noise residual
-        return model_pred
+
+        # remove pred vars for pixart output (see DiT for more)
+        return model_pred.chunk(2, dim=1)[0]

--- a/hcpdiff/workflow/diffusion.py
+++ b/hcpdiff/workflow/diffusion.py
@@ -220,12 +220,18 @@ class PixartDenoiseAction(BasicAction):
             latent_model_input = noise_sampler.sigma_scheduler.c_in(t)*latent_model_input
             t_in = noise_sampler.sigma_scheduler.c_noise(t)
 
+            if t_in.dim() == 0:
+                t_in = t_in.unsqueeze(0).expand(latent_model_input.shape[0])
+            
             noise_pred = denoiser(latent_model_input, prompt_embeds, t_in, encoder_attention_mask=encoder_attention_mask,
                                 cross_attention_kwargs=cross_attention_kwargs, ).sample
             # perform guidance
             if self.guidance_scale>1:
                 noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                 noise_pred = noise_pred_uncond+self.guidance_scale*(noise_pred_text-noise_pred_uncond)
+        
+        # remove vars from DiT
+        noise_pred, _ = noise_pred.chunk(2, dim=1)
 
         return {'noise_pred':noise_pred}
 

--- a/hcpdiff/workflow/diffusion.py
+++ b/hcpdiff/workflow/diffusion.py
@@ -10,7 +10,7 @@ from rainbowneko.infer import BasicAction, Actions
 from torch.cuda.amp import autocast
 from einops import rearrange, repeat
 from hcpdiff.models.compose import SDXLTextEncoder
-from diffusers import FluxTransformer2DModel
+from diffusers import FluxTransformer2DModel, PixArtTransformer2DModel
 
 try:
     from diffusers.utils import randn_tensor
@@ -304,6 +304,8 @@ class DiffusionStepAction(BasicAction):
                 self.act_noise_pred = FluxDenoiseAction(guidance_scale=self.guidance_scale, true_cfg=self.true_cfg)
             elif isinstance(TE, SDXLTextEncoder):
                 self.act_noise_pred = SDXLDenoiseAction(guidance_scale=self.guidance_scale)
+            elif isinstance(denoiser, PixArtTransformer2DModel):
+                self.act_noise_pred = PixartDenoiseAction(guidance_scale=self.guidance_scale)
             else:
                 self.act_noise_pred = SD15DenoiseAction(guidance_scale=self.guidance_scale)
 

--- a/hcpdiff/workflow/diffusion.py
+++ b/hcpdiff/workflow/diffusion.py
@@ -204,6 +204,31 @@ class SDXLDenoiseAction(BasicAction):
 
         return {'noise_pred':noise_pred}
 
+class PixartDenoiseAction(BasicAction):
+    def __init__(self, guidance_scale: float = 7.0, key_map_in=None, key_map_out=None):
+        super().__init__(key_map_in, key_map_out)
+        self.guidance_scale = guidance_scale
+
+    def forward(self, denoiser, noise_sampler: BaseSampler, t, latents, prompt_embeds, encoder_attention_mask=None,
+                cross_attention_kwargs=None, dtype='fp32', amp=None, model_offload=False, **states):
+
+        if model_offload:
+            to_cuda(denoiser)  # to_cpu in VAE
+
+        with autocast(enabled=amp is not None, dtype=get_dtype(amp)):
+            latent_model_input = torch.cat([latents]*2) if self.guidance_scale>1 else latents
+            latent_model_input = noise_sampler.sigma_scheduler.c_in(t)*latent_model_input
+            t_in = noise_sampler.sigma_scheduler.c_noise(t)
+
+            noise_pred = denoiser(latent_model_input, prompt_embeds, t_in, encoder_attention_mask=encoder_attention_mask,
+                                cross_attention_kwargs=cross_attention_kwargs, ).sample
+            # perform guidance
+            if self.guidance_scale>1:
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond+self.guidance_scale*(noise_pred_text-noise_pred_uncond)
+
+        return {'noise_pred':noise_pred}
+
 class FluxDenoiseAction(BasicAction):
     def __init__(self, guidance_scale: float = 7.0, true_cfg=False, key_map_in=None, key_map_out=None):
         super().__init__(key_map_in, key_map_out)


### PR DESCRIPTION
In PixArtWrapper, T5Encoder do not need position_ids (It use relative position embedding for key and query), thus overwrite a new `forward_TE` method.
In PixartDenoiseAction,  `forward` method require different param order for 'encoder_hidden_states' and 'timesteps' against Unet (DiT need 'encoder_hidden_states' before 'timesteps', Unet need the opposite one).