### PR TITLE
modify hcpdiff.diffusion.sampler.base class Sampler def x0_to_velocity

### DIFF
--- a/hcpdiff/diffusion/sampler/base.py
+++ b/hcpdiff/diffusion/sampler/base.py
@@ -121,10 +121,8 @@ class Sampler(BaseSampler):
         d_alpha, d_sigma = self.sigma_scheduler.velocity(t)
         if eps is None:
             eps = self.x0_to_eps(x_0, x_t, t)
-            
-        num_dim_to_expand = len(x_0.shape) - 1
-        d_alpha = d_alpha.view(-1, *[1]*num_dim_to_expand)
-        d_sigma = d_sigma.view(-1, *[1]*num_dim_to_expand)
+        d_alpha = (d_alpha,x_0.ndim-1).to(x_0.device)
+        d_sigma = (d_sigma,eps.ndim-1).to(eps.device)
         return d_alpha*x_0+d_sigma*eps
 
     def eps_to_x0(self, eps, x_t, t):

--- a/hcpdiff/diffusion/sampler/base.py
+++ b/hcpdiff/diffusion/sampler/base.py
@@ -121,6 +121,10 @@ class Sampler(BaseSampler):
         d_alpha, d_sigma = self.sigma_scheduler.velocity(t)
         if eps is None:
             eps = self.x0_to_eps(x_0, x_t, t)
+            
+        num_dim_to_expand = len(x_0.shape) - 1
+        d_alpha = d_alpha.view(-1, *[1]*num_dim_to_expand)
+        d_sigma = d_sigma.view(-1, *[1]*num_dim_to_expand)
         return d_alpha*x_0+d_sigma*eps
 
     def eps_to_x0(self, eps, x_t, t):

--- a/hcpdiff/diffusion/sampler/base.py
+++ b/hcpdiff/diffusion/sampler/base.py
@@ -121,8 +121,8 @@ class Sampler(BaseSampler):
         d_alpha, d_sigma = self.sigma_scheduler.velocity(t)
         if eps is None:
             eps = self.x0_to_eps(x_0, x_t, t)
-        d_alpha = (d_alpha,x_0.ndim-1).to(x_0.device)
-        d_sigma = (d_sigma,eps.ndim-1).to(eps.device)
+        d_alpha = add_dims(d_alpha, x_0.ndim-1).to(x_0.device)
+        d_sigma = add_dims(d_sigma, eps.ndim-1).to(eps.device)
         return d_alpha*x_0+d_sigma*eps
 
     def eps_to_x0(self, eps, x_t, t):


### PR DESCRIPTION
original code meet problems when batch_size > 1

original code makes 'd_alpha, d_sigma' 1 dim torch.Tensor(size: [batch_size]), when batch_size == 1, it can be boradcast to any tensor shape of 'x_0' and 'eps', but when batch_size == 2, d_alpha.shape == [2], it will lead to problem that 'The size of tensor a (2) must match the size of tensor b (80) at non-singleton dimension 4' (can not boradcast)

        """
        batch_size == 1:
        ic| x_0.shape: torch.Size([1, 16, 16, 44, 80])
        ic| x_t.shape: torch.Size([1, 16, 16, 44, 80])
        ic| eps.shape: torch.Size([1, 16, 16, 44, 80])
        ic| d_alpha.shape: torch.Size([1]), d_sigma.shape: torch.Size([1])

        batch_size == 2:
        ic| x_0.shape: torch.Size([2, 16, 32, 44, 80])
        ic| x_t.shape: torch.Size([2, 16, 32, 44, 80])
        ic| eps.shape: torch.Size([2, 16, 32, 44, 80])
        ic| d_alpha.shape: torch.Size([2]), d_sigma.shape: torch.Size([2])
        """

Thus, I add some dimension for 'd_alpha' and 'd_sigma' to [2, 1, 1, 1, 1], helping multiple with 'x_0 ' and 'eps'